### PR TITLE
Upgrade depreciating price_in for price_for

### DIFF
--- a/app/models/spree/order_contents_decorator.rb
+++ b/app/models/spree/order_contents_decorator.rb
@@ -45,6 +45,7 @@ Spree::OrderContents.class_eval do
       ad_hoc_option_value_ids ||= []
       customizations_offset_price = 0
       ad_hoc_options_offset_price = 0
+      pricing_options = Spree::Variant::PricingOptions.new(currency: order.currency)
 
       if product_customizations_values.count > 0
         customizations_offset_price = line_item.add_customizations(product_customizations_values)
@@ -56,7 +57,7 @@ Spree::OrderContents.class_eval do
         ad_hoc_options_offset_price = line_item.add_ad_hoc_option_values(ad_hoc_option_value_ids)
       end
 
-      line_item.price = variant.price_in(order.currency).amount + customizations_offset_price + ad_hoc_options_offset_price
+      line_item.price = variant.price_for(pricing_options).money.amount + customizations_offset_price + ad_hoc_options_offset_price
 
       return line_item
   end


### PR DESCRIPTION
To fix this depreciation warning:
```
DEPRECATION WARNING: price_in is deprecated and will be removed from Solidus 3.0 (use price_for instead) (called from flexi_variants at /Users/neel/.rvm/gems/ruby-2.5.1/bundler/gems/solidus_flexi_variants-9f9dccfbf891/app/models/spree/order_contents_decorator.rb:59)
```