### PR TITLE
Move comparison hooks registration and use require_dependency.

### DIFF
--- a/app/decorators/spree/flexi_order_decorator.rb
+++ b/app/decorators/spree/flexi_order_decorator.rb
@@ -33,6 +33,6 @@ module Spree
       existing_ad_hoc_opt_vals.pluck(:id).sort == new_ad_hoc_opt_vals.map(&:to_i).sort
     end
 
-    ::Spree::Order.prepend(self) unless ::Spree::Order.ancestors.include?(self)
+    ::Spree::Order.prepend(self)
   end
 end

--- a/app/decorators/spree/line_item_decorator.rb
+++ b/app/decorators/spree/line_item_decorator.rb
@@ -69,6 +69,6 @@ module Spree
       return ad_hoc_options_offset_price
     end
 
-    ::Spree::LineItem.prepend(self) unless ::Spree::LineItem.ancestors.include?(self)
+    ::Spree::LineItem.prepend(self)
   end
 end

--- a/app/decorators/spree/option_type_decorator.rb
+++ b/app/decorators/spree/option_type_decorator.rb
@@ -5,5 +5,5 @@ module Spree
     end
   end
 
-  ::Spree::OptionType.prepend(self) unless ::Spree::OptionType.ancestors.include?(self)
+  ::Spree::OptionType.prepend(self)
 end

--- a/app/decorators/spree/option_value_decorator.rb
+++ b/app/decorators/spree/option_value_decorator.rb
@@ -5,6 +5,6 @@ module Spree
       base.has_many :ad_hoc_option_values, dependent: :destroy
     end
 
-    ::Spree::OptionValue.prepend(self) unless ::Spree::OptionValue.ancestors.include?(self)
+    ::Spree::OptionValue.prepend(self)
   end
 end

--- a/app/decorators/spree/order_contents_decorator.rb
+++ b/app/decorators/spree/order_contents_decorator.rb
@@ -80,6 +80,6 @@ module Spree
       end
     end
 
-    ::Spree::OrderContents.prepend(self) unless ::Spree::OrderContents.ancestors.include?(self)
+    ::Spree::OrderContents.prepend(self)
   end
 end

--- a/app/decorators/spree/orders_controller_decorator.rb
+++ b/app/decorators/spree/orders_controller_decorator.rb
@@ -42,6 +42,6 @@ module Spree
       params[:options][:customization_price] = params[:customization_price] if params[:customization_price]
     end
 
-    ::Spree::OrdersController.prepend(self) unless ::Spree::OrdersController.ancestors.include?(self)
+    ::Spree::OrdersController.prepend(self)
   end
 end

--- a/app/decorators/spree/product_decorator.rb
+++ b/app/decorators/spree/product_decorator.rb
@@ -24,6 +24,6 @@ module Spree
       end
     end
 
-    ::Spree::Product.prepend(self) unless ::Spree::Product.ancestors.include?(self)
+    ::Spree::Product.prepend(self)
   end
 end

--- a/app/decorators/spree/products_controller_decorator.rb
+++ b/app/decorators/spree/products_controller_decorator.rb
@@ -30,6 +30,6 @@ module Spree
       respond_with(@product)
     end
 
-    ::Spree::ProductsController.prepend(self) unless ::Spree::ProductsController.ancestors.include?(self)
+    ::Spree::ProductsController.prepend(self)
   end
 end

--- a/lib/solidus_flexi_variants/engine.rb
+++ b/lib/solidus_flexi_variants/engine.rb
@@ -11,23 +11,21 @@ module SolidusFlexiVariants
 
     def self.activate
       Dir.glob(File.join(File.dirname(__FILE__), "../../app/decorators/**/*_decorator*.rb")) do |c|
-        Rails.configuration.cache_classes ? require_dependency(c) : load(c)
+        require_dependency(c)
       end
 
       Spree::Core::Environment::Calculators.class_eval do
         attr_accessor :product_customization_types
       end
+
+      Spree::Order.register_line_item_comparison_hook(:product_customizations_match)
+      Spree::Order.register_line_item_comparison_hook(:ad_hoc_option_values_match)
     end
 
     config.to_prepare &method(:activate).to_proc
 
     initializer "spree.flexi_variants.preferences", after: "spree.environment" do |app|
       SolidusFlexiVariants::Config = Spree::FlexiVariantsConfiguration.new
-    end
-
-    initializer "spree.flexi_variants.register.line_item_comparision_hooks" do |app|
-      Spree::Order.register_line_item_comparison_hook(:product_customizations_match)
-      Spree::Order.register_line_item_comparison_hook(:ad_hoc_option_values_match)
     end
 
     initializer "spree.flexi_variants.assets.precompile" do |app|


### PR DESCRIPTION
Move comparison hooks registration outside of Railtie initializers to self.activate method after require_dependency, which triggers Zeitwerk. Use require_dependency at all times to remove check for ancestors when prepending.

Note: This PR includes a corresponding acceptance test in the main Printavo repo:
https://github.com/Printavo/Printavo/pull/1375
We would need to get this PR merged in first before we can merge the acceptance test.

## What was happening?
All the action happens in `engine.rb`:
```ruby
    def self.activate
      Dir.glob(File.join(File.dirname(__FILE__), "../../app/decorators/**/*_decorator*.rb")) do |c|
        Rails.configuration.cache_classes ? require_dependency(c) : load(c)
      end

      Spree::Core::Environment::Calculators.class_eval do
        attr_accessor :product_customization_types
      end
    end

    initializer "spree.flexi_variants.register.line_item_comparision_hooks" do |app|
      Spree::Order.register_line_item_comparison_hook(:product_customizations_match)
      Spree::Order.register_line_item_comparison_hook(:ad_hoc_option_values_match)
    end
```
1. The Railtie `initializer` is called before `self.activate`. `ActiveSupport::Dependencies::ModuleConstMissing` is triggered by seeing `Spree::Order` in the Railtie initializer. It loads `Spree::Order` and runs through its class definitions.
`order.rb` (the file for `Spree::Order`) contains the following in its class definitions:
```ruby
    class_attribute :line_item_comparison_hooks
    self.line_item_comparison_hooks = Set.new
```
2. We register the comparison hooks in the Railtie initializer.
3. Later, the `self.activate` method is run. `ActiveSupport::Dependencies::ZeitwerkIntegration::RequireDependency` is triggered by `require_dependency`. It loads `flexi_order_decorator.rb`. The last line of `flexi_order_decorator.rb` is `::Spree::Order.prepend(self)`. Zeitwerk doesn't recognize `Spree::Order`, so it loads `Spree::Order` and runs through its class definition. As it runs through the code I mentioned above, `line_item_comparison_hooks` is now an empty Set again.

## The Fix
First thing I tried was to use `require_dependency` at all times and remove the check for ancestors (which we needed to do anyways). This didn't solve the problem. I saw the exact behavior I described above.
Next, I thought we would definitely want to register the comparison hooks AFTER the `require_dependency` triggers `Spree::Order`. So one simple solution is to move the line item comparison hook registration logic to the lines after `require_dependency` is called in the `self.activate` method.

## Why do we care?
This allows us to use the existing matcher `product_customizations_match`:
```ruby
    # produces a list of [customizable_product_option.id,value] pairs for subsequent comparison
    def customization_pairs(product_customizations)
      pairs = product_customizations.map(&:customized_product_options).flatten.map do |m|
        [m.customizable_product_option.id, m.value.present? ? m.value : m.customization_image.to_s ]
      end

      Set.new pairs
    end

    def product_customizations_match(line_item, options)
      existing_customizations = line_item.product_customizations
      new_customizations = options[:product_customizations]

      return true if existing_customizations.empty? && new_customizations.empty?

      return false unless existing_customizations.pluck(:product_customization_type_id).sort == new_customizations.pluck(:product_customization_type_id).sort

      existing_vals = customization_pairs(existing_customizations)
      new_vals = customization_pairs(new_customizations)

      # do a set-compare here
      existing_vals == new_vals
    end
```

![image](https://user-images.githubusercontent.com/1609290/80837848-3f948800-8bbd-11ea-9038-cdf68b35cfd6.png)